### PR TITLE
Allow explicit type mappings for interfaces declared in the project

### DIFF
--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -605,10 +605,16 @@ public class CSharpBuilder extends ASTVisitor {
 	private CSTypeDeclaration typeDeclarationFor(TypeDeclaration node) {		
 		final String typeName = typeName(node);
 		if (node.isInterface()) {
-			if (isValidCSInterface(node.resolveBinding()))
-				return new CSInterface(processInterfaceName(node));
-			else
+			if (isValidCSInterface(node.resolveBinding())) {
+				boolean overriddenName = !typeName.equals(node.getName().toString());
+				if (overriddenName) {
+					return new CSInterface(typeName);
+				} else {
+					return new CSInterface(processInterfaceName(node));
+				}
+			} else {
 				return new CSClass(typeName, CSClassModifier.Abstract);
+			}
 		}
 
 		if (isStruct(node)) {


### PR DESCRIPTION
Previously all _references_ to an interface with an explicit type mapping would use the name provided by the mapping, but the declaration of the interface itself (and the corresponding filename) would ignore the mapped name.
