### PR TITLE
Add the -paramCountFileNames configuration option

### DIFF
--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -638,7 +638,14 @@ public class CSharpBuilder extends ASTVisitor {
 
 	private CSTypeDeclaration checkForMainType(TypeDeclaration node, CSTypeDeclaration type) {
 		if (isMainType(node)) {
-			setCompilationUnitElementName(type.name());
+			String name = type.name();
+			if (_configuration.paramCountFileNames()) {
+				if (type.typeParameters().size() > 0) {
+					name += "`" + Integer.toString(type.typeParameters().size());
+				}
+			}
+
+			setCompilationUnitElementName(name);
 		}
 		return type;
 	}

--- a/sharpen.core/src/sharpen/core/Configuration.java
+++ b/sharpen.core/src/sharpen/core/Configuration.java
@@ -88,6 +88,8 @@ public abstract class Configuration {
 	
 	private boolean _organizeUsings;
 	
+	private boolean _paramCountFileNames;
+
 	private boolean _junitConvert;
 	
 	private List<String> _fullyQualifiedTypes = new ArrayList<String>();
@@ -389,6 +391,14 @@ public abstract class Configuration {
 	
 	public boolean organizeUsings() {
 		return _organizeUsings;
+	}
+
+	public void enableParamCountFileNames() {
+		_paramCountFileNames = true;
+	}
+
+	public boolean paramCountFileNames() {
+		return _paramCountFileNames;
 	}
 	
 	public void enableJUnitConversion () {

--- a/sharpen.core/src/sharpen/core/SharpenApplication.java
+++ b/sharpen.core/src/sharpen/core/SharpenApplication.java
@@ -117,6 +117,10 @@ public class SharpenApplication implements IApplication {
 			ods("Organize usings mode on.");
 			configuration.enableOrganizeUsings();
 		}
+		if (_args.paramCountFileNames) {
+			ods("Generic parameter count appended to file names.");
+			configuration.enableParamCountFileNames();
+		}
 		if (_args.junitConversion) {
 			ods("JUnit conversion mode on.");
 			configuration.enableJUnitConversion();

--- a/sharpen.core/src/sharpen/core/SharpenCommandLine.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLine.java
@@ -71,6 +71,7 @@ public class SharpenCommandLine {
 	final public Map<String, Configuration.MemberMapping> memberMappings = new HashMap<String, Configuration.MemberMapping>();
 	public boolean nativeInterfaces;
 	public boolean organizeUsings;
+	public boolean paramCountFileNames;
 	final public List<String> fullyQualifiedTypes = new ArrayList<String>();
 	final public List<String> partialTypes = new ArrayList<String>();
 	public String headerFile;

--- a/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
@@ -81,6 +81,8 @@ class SharpenCommandLineParser extends CommandLineParser {
 			_cmdLine.classpath.add(consumeNext());
 		} else if (areEqual(arg, "-srcFolder")) {
 			_cmdLine.sourceFolders.add(consumeNext());
+		} else if (areEqual(arg, "-paramCountFileNames")) {
+			_cmdLine.paramCountFileNames = true;
 		} else if (areEqual(arg, "-nativeTypeSystem")) {
 			_cmdLine.nativeTypeSystem = true;
 		} else if (areEqual(arg, "-nativeInterfaces")) {


### PR DESCRIPTION
When the `-paramCountFileNames` option is specified, the file names for generic types will have the generic parameter count appended. For example, a class `Foo<T, U>` would be placed in a file named:

```
Foo`2.cs
```

The file names for non-generic types are not changed.
