### PR TITLE
Better support for AnnotationTypeMemberDeclaration

### DIFF
--- a/sharpen.core/src/sharpen/core/Annotations.java
+++ b/sharpen.core/src/sharpen/core/Annotations.java
@@ -5,7 +5,7 @@ import org.eclipse.jdt.core.dom.*;
 
 public interface Annotations {
 
-	TagElement effectiveAnnotationFor(MethodDeclaration node, String annotation);
+	TagElement effectiveAnnotationFor(BodyDeclaration node, String annotation);
 
 	String annotatedPropertyName(MethodDeclaration node);
 

--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -1438,19 +1438,19 @@ public class CSharpBuilder extends ASTVisitor {
 	}
 	
 	private String propertyName(IMethodBinding binding) {
-		return propertyName(declaringNode(binding));
+		return propertyName((MethodDeclaration)declaringNode(binding));
 	}
 	
-	private boolean isProperty(MethodDeclaration node) {
+	private boolean isProperty(BodyDeclaration node) {
 		return isTaggedAsProperty(node)
 			|| isMappedToProperty(node);
 	}
 
-	private boolean isTaggedAsProperty(MethodDeclaration node) {
+	private boolean isTaggedAsProperty(BodyDeclaration node) {
 	    return isTaggedDeclaration(node, SharpenAnnotations.SHARPEN_PROPERTY);
     }
 
-	private boolean isTaggedDeclaration(MethodDeclaration node, final String tag) {
+	private boolean isTaggedDeclaration(BodyDeclaration node, final String tag) {
 		return effectiveAnnotationFor(node, tag) != null;
 	}
 
@@ -1757,7 +1757,7 @@ public class CSharpBuilder extends ASTVisitor {
 		return effectiveAnnotationFor(node, SharpenAnnotations.SHARPEN_EVENT);
 	}
 
-	private TagElement effectiveAnnotationFor(MethodDeclaration node, final String annotation) {
+	private TagElement effectiveAnnotationFor(BodyDeclaration node, final String annotation) {
 	    return my(Annotations.class).effectiveAnnotationFor(node, annotation);
 	}
 
@@ -2688,7 +2688,7 @@ public class CSharpBuilder extends ASTVisitor {
 	}
 
 	private boolean isTaggedMethod(final IMethodBinding binding, final String tag) {
-	    final MethodDeclaration declaration = declaringNode(binding);
+	    final BodyDeclaration declaration = declaringNode(binding);
 		if (null == declaration) {
 			return false;
 		}
@@ -2747,7 +2747,7 @@ public class CSharpBuilder extends ASTVisitor {
     }
 
 	private void processMacroInvocation(MethodInvocation node) {
-		final MethodDeclaration declaration = declaringNode(node.resolveMethodBinding());
+		final MethodDeclaration declaration = (MethodDeclaration)declaringNode(node.resolveMethodBinding());
 		final TagElement macro = effectiveAnnotationFor(declaration, SharpenAnnotations.SHARPEN_MACRO);
 		final CSMacro code = new CSMacro(JavadocUtility.singleTextFragmentFrom(macro));
 		
@@ -2907,12 +2907,12 @@ public class CSharpBuilder extends ASTVisitor {
 
 	private void processEventSubscription(MethodInvocation node) {
 
-		final MethodDeclaration addListener = declaringNode(node.resolveMethodBinding());
+		final MethodDeclaration addListener = (MethodDeclaration)declaringNode(node.resolveMethodBinding());
 		assertValidEventAddListener(node, addListener);
 
 		final MethodInvocation eventInvocation = (MethodInvocation) node.getExpression();
 
-		final MethodDeclaration eventDeclaration = declaringNode(eventInvocation.resolveMethodBinding());
+		final MethodDeclaration eventDeclaration = (MethodDeclaration)declaringNode(eventInvocation.resolveMethodBinding());
 		mapEventSubscription(node, getEventArgsType(eventDeclaration), getEventHandlerTypeName(eventDeclaration));
 	}
 
@@ -2998,7 +2998,7 @@ public class CSharpBuilder extends ASTVisitor {
 	}
 
 	private boolean isTaggedMethodInvocation(final IMethodBinding binding, final String tag) {
-		final MethodDeclaration method = declaringNode(originalMethodBinding(binding));
+		final BodyDeclaration method = declaringNode(originalMethodBinding(binding));
 		if (null == method) {
 			return false;
 		}
@@ -3419,16 +3419,16 @@ public class CSharpBuilder extends ASTVisitor {
 	}
 
 	private boolean isIgnored(IMethodBinding binding) {
-		final MethodDeclaration dec = declaringNode(binding);
+		final BodyDeclaration dec = declaringNode(binding);
 		return dec != null && SharpenAnnotations.hasIgnoreAnnotation(dec);
 	}
 
 	private boolean stubIsProperty(IMethodBinding method) {
-		final MethodDeclaration dec = declaringNode(method);
+		final BodyDeclaration dec = declaringNode(method);
 		return dec != null && isProperty(dec);
 	}
 
-	private MethodDeclaration declaringNode(IMethodBinding method) {
+	private BodyDeclaration declaringNode(IMethodBinding method) {
 		return findDeclaringNode(method);
 	}
 
@@ -3469,7 +3469,7 @@ public class CSharpBuilder extends ASTVisitor {
 	}
 
 	private void safeProcessDisableTags(IMethodBinding method, CSMember member) {
-		final MethodDeclaration node = declaringNode(method);
+		final BodyDeclaration node = declaringNode(method);
 		if (node == null) return;
 		
 		processDisableTags(node, member);
@@ -3700,8 +3700,17 @@ public class CSharpBuilder extends ASTVisitor {
 		return eventTagFor(declaring) != null;
 	}
 
-	private boolean isMappedToProperty(MethodDeclaration original) {
-		final MemberMapping mapping = effectiveMappingFor(original.resolveBinding());
+	private boolean isMappedToProperty(BodyDeclaration original) {
+		IMethodBinding binding;
+		if (original instanceof MethodDeclaration) {
+			binding = ((MethodDeclaration)original).resolveBinding();
+		} else if (original instanceof AnnotationTypeMemberDeclaration) {
+			binding = ((AnnotationTypeMemberDeclaration)original).resolveBinding();
+		} else {
+			throw new UnsupportedOperationException();
+		}
+
+		final MemberMapping mapping = effectiveMappingFor(binding);
 		if (null == mapping)
 			return false;
 		return mapping.kind == MemberKind.Property;

--- a/sharpen.core/src/sharpen/core/internal/MappingsImpl.java
+++ b/sharpen.core/src/sharpen/core/internal/MappingsImpl.java
@@ -177,28 +177,57 @@ public class MappingsImpl implements Mappings {
 		
 		//TODO: Always check method in current class first (irrespective to sharpen.ignore.implements/extends)?
 		//TODO: Check ignore implements also 
-		
-		MethodDeclaration method = (MethodDeclaration) (declaringClassIgnoresExtends  
-										? findDeclaringNode(binding) 
-										: findDeclaringNode(originalMethodBinding(binding))) ;
-		if (method == null)
+
+		BodyDeclaration declaration;
+		if (declaringClassIgnoresExtends) {
+			declaration = findDeclaringNode(binding);
+		} else {
+			declaration = findDeclaringNode(originalMethodBinding(binding));
+		}
+
+		if (declaration == null) {
 			return null;
-		
-		if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_INDEXER))
-			return new MemberMapping(null, MemberKind.Indexer);
-		
-		if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_EVENT))
-			return new MemberMapping(binding.getName(), MemberKind.Property);
-		
-		if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_PROPERTY))
-			return new MemberMapping(annotatedPropertyName(method), MemberKind.Property);
-		
-		if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_RENAME))
-			return new MemberMapping(annotatedRenaming(method), MemberKind.Method);
-		
-		//TODO: Check originalMethodBinding if declaringClassIgnoresExtends == true
-		//      and we reach this point?
-		return null;
+		}
+
+		if (declaration instanceof MethodDeclaration) {
+			MethodDeclaration method = (MethodDeclaration)declaration;
+			if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_INDEXER))
+				return new MemberMapping(null, MemberKind.Indexer);
+
+			if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_EVENT))
+				return new MemberMapping(binding.getName(), MemberKind.Property);
+
+			if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_PROPERTY))
+				return new MemberMapping(annotatedPropertyName(method), MemberKind.Property);
+
+			if (isAnnotatedWith(method, SharpenAnnotations.SHARPEN_RENAME))
+				return new MemberMapping(annotatedRenaming(method), MemberKind.Method);
+
+			//TODO: Check originalMethodBinding if declaringClassIgnoresExtends == true
+			//      and we reach this point?
+			return null;
+		}
+		else if (declaration instanceof AnnotationTypeMemberDeclaration) {
+			AnnotationTypeMemberDeclaration member = (AnnotationTypeMemberDeclaration)declaration;
+			if (isAnnotatedWith(member, SharpenAnnotations.SHARPEN_INDEXER))
+				return new MemberMapping(null, MemberKind.Indexer);
+
+			if (isAnnotatedWith(member, SharpenAnnotations.SHARPEN_EVENT))
+				return new MemberMapping(binding.getName(), MemberKind.Property);
+
+			if (isAnnotatedWith(member, SharpenAnnotations.SHARPEN_PROPERTY))
+				throw new UnsupportedOperationException();
+
+			if (isAnnotatedWith(member, SharpenAnnotations.SHARPEN_RENAME))
+				return new MemberMapping(annotatedRenaming(member), MemberKind.Method);
+
+			//TODO: Check originalMethodBinding if declaringClassIgnoresExtends == true
+			//      and we reach this point?
+			return null;
+		}
+		else {
+			throw new UnsupportedOperationException();
+		}
 	}
 
 	private boolean isDeclaringClassIgnoringExtends(final IMethodBinding binding) {


### PR DESCRIPTION
This still doesn't generate attribute classes for annotation interfaces, but it does allow for reasonable code generation in files containing code that references members of an annotation type (previously code generation would completely fail for the file).
