### PR TITLE
Default visibility for methods in interfaces converted to C# classes is public

### DIFF
--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -3621,10 +3621,19 @@ public class CSharpBuilder extends ASTVisitor {
 			return CSVisibility.Public;
 		}
 
-		return mapVisibility(node.getModifiers());
+		CSVisibility defaultVisibility = CSVisibility.Internal;
+		if (node.getParent() instanceof TypeDeclaration && ((TypeDeclaration)node.getParent()).isInterface()) {
+			defaultVisibility = CSVisibility.Public;
+		}
+
+		return mapVisibility(node.getModifiers(), defaultVisibility);
 	}
 
 	CSVisibility mapVisibility(int modifiers) {
+		return mapVisibility(modifiers, CSVisibility.Internal);
+	}
+
+	CSVisibility mapVisibility(int modifiers, CSVisibility defaultVisibility) {
 		if (Modifier.isPublic(modifiers)) {
 			return CSVisibility.Public;
 		}
@@ -3636,7 +3645,7 @@ public class CSharpBuilder extends ASTVisitor {
 		if (Modifier.isPrivate(modifiers)) {
 			return CSVisibility.Private;
 		}
-		return CSVisibility.Internal;
+		return defaultVisibility;
 	}
 
 	protected CSTypeReferenceExpression mappedTypeReference(Type type) {


### PR DESCRIPTION
If no visibility specifier is given for an interface method in Java, and the interface is converted to a C# abstract class (due to interface constants), the generated method's visibility should be public, not internal.
