### PR TITLE
Constructors don't inherit visibility

### DIFF
--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -1538,7 +1538,7 @@ public class CSharpBuilder extends ASTVisitor {
 		visitBodyDeclarationBlock(node, node.getBody(), method);
 		
 		IMethodBinding overriden = getOverridedMethod(node);
-		if (overriden != null) {
+		if (!node.isConstructor() && overriden != null) {
 			CSVisibility vis = mapVisibility (overriden.getModifiers());
 			if (vis == CSVisibility.ProtectedInternal && !overriden.getDeclaringClass().isFromSource())
 				vis = CSVisibility.Protected;


### PR DESCRIPTION
Constructors don't override inherited methods in the traditional sense, and don't need to inherit the visibility modifiers from constructors in super classes.
