### PR TITLE
Add support for try-with-resources statements

### DIFF
--- a/sharpen.core/src/sharpen/core/StandaloneConverter.java
+++ b/sharpen.core/src/sharpen/core/StandaloneConverter.java
@@ -33,7 +33,7 @@ public class StandaloneConverter extends SharpenConversion {
 	
 	public StandaloneConverter(Configuration configuration) {
 		super(configuration);
-		_parser = ASTParser.newParser(AST.JLS3);
+		_parser = ASTParser.newParser(AST.JLS4);
 	}
 	
 	public CSCompilationUnit run() {

--- a/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
+++ b/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
@@ -136,7 +136,17 @@ public class CSharpPrinter extends CSVisitor {
 	public void visit(CSUsing node) {
 		writeLine("using " + node.namespace() + ";");
 	}
-	
+
+	@Override
+	public void visit(CSUsingStatement node) {
+		printPrecedingComments(node);
+
+		writeIndented("using (");
+		node.expression().accept(this);
+		writeLine(")");
+		node.body().accept(this);
+	}
+
 	public void visit(CSClass node) {
 		writeType(node);
 	}

--- a/sharpen.core/src/sharpen/core/csharp/ast/CSUsingStatement.java
+++ b/sharpen.core/src/sharpen/core/csharp/ast/CSUsingStatement.java
@@ -1,0 +1,18 @@
+package sharpen.core.csharp.ast;
+
+public class CSUsingStatement extends CSExpressionStatement {
+	private CSBlock _body = new CSBlock();
+
+	public CSUsingStatement(int startPosition, CSExpression expression) {
+		super(startPosition, expression);
+	}
+
+	@Override
+	public void accept(CSVisitor visitor) {
+		visitor.visit(this);
+	}
+	
+	public CSBlock body() {
+		return _body ;
+	}
+}

--- a/sharpen.core/src/sharpen/core/csharp/ast/CSVisitor.java
+++ b/sharpen.core/src/sharpen/core/csharp/ast/CSVisitor.java
@@ -242,4 +242,7 @@ public class CSVisitor {
 
 	public void visit(CSGotoStatement node) {
 	}
+
+	public void visit(CSUsingStatement node) {
+	}
 }

--- a/sharpen.core/src/sharpen/core/framework/ConversionBatch.java
+++ b/sharpen.core/src/sharpen/core/framework/ConversionBatch.java
@@ -17,7 +17,7 @@ public abstract class ConversionBatch {
 	private boolean _continueOnError;
 
 	public ConversionBatch() {
-		_parser = ASTParser.newParser(AST.JLS3);
+		_parser = ASTParser.newParser(AST.JLS4);
 		_parser.setKind(ASTParser.K_COMPILATION_UNIT);
 	}
 


### PR DESCRIPTION
Java SE 7 adds support for [try-with-resources](http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) statments which are ignored currently.
