### PR TITLE
Add option -maxColumns to set the line wrapping width

### DIFF
--- a/sharpen.core/src/sharpen/core/Configuration.java
+++ b/sharpen.core/src/sharpen/core/Configuration.java
@@ -80,6 +80,8 @@ public abstract class Configuration {
 
 	private String _indentString;
 
+	private int _maxColumns = 80;
+
 	private boolean _nativeTypeSystem = false;
 	
 	private boolean _ignoreErrors = false;
@@ -225,6 +227,14 @@ public abstract class Configuration {
 
 	public void setIndentString(String indentString) {
 		this._indentString = indentString;
+	}
+
+	public int getMaxColumns() {
+		return _maxColumns;
+	}
+
+	public void setMaxColumns(int maxColumns) {
+		this._maxColumns = maxColumns;
 	}
 
 	public void enableNativeTypeSystem() {

--- a/sharpen.core/src/sharpen/core/SharpenApplication.java
+++ b/sharpen.core/src/sharpen/core/SharpenApplication.java
@@ -115,6 +115,9 @@ public class SharpenApplication implements IApplication {
 
 			configuration.setIndentString(indent.toString());
 		}
+		if (_args.maxColumns != 0) {
+			configuration.setMaxColumns(_args.maxColumns);
+		}
 		if (_args.nativeTypeSystem) {
 			ods("Native type system mode on.");
 			configuration.enableNativeTypeSystem();

--- a/sharpen.core/src/sharpen/core/SharpenCommandLine.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLine.java
@@ -66,6 +66,7 @@ public class SharpenCommandLine {
 	public PascalCaseOptions pascalCase = PascalCaseOptions.None;
 	public boolean indentWithSpaces;
 	public int indentSize = 4;
+	public int maxColumns = 80;
 	public String project;
 	final public List<String> classpath = new ArrayList<String>();
 	final public List<String> sourceFolders = new ArrayList<String>();

--- a/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
@@ -89,6 +89,8 @@ class SharpenCommandLineParser extends CommandLineParser {
 			_cmdLine.indentWithSpaces = true;
 		} else if (areEqual(arg, "-indentSize")) {
 			_cmdLine.indentSize = Integer.parseInt(consumeNext());
+		} else if (areEqual(arg, "-maxColumns")) {
+			_cmdLine.maxColumns = Integer.parseInt(consumeNext());
 		} else if (areEqual(arg, "-nativeInterfaces")) {
 			_cmdLine.nativeInterfaces = true;
 		} else if (areEqual(arg, "-organizeUsings")) {

--- a/sharpen.core/src/sharpen/core/SharpenConversion.java
+++ b/sharpen.core/src/sharpen/core/SharpenConversion.java
@@ -95,7 +95,7 @@ public class SharpenConversion {
 
 	private void printTree(CSCompilationUnit unit) {
 		CSharpPrinter printer = getPrinter();
-		printer.setWriter(_writer, _configuration.getIndentString());
+		printer.setWriter(_writer, _configuration.getIndentString(), _configuration.getMaxColumns());
 		printer.print(unit);
 	}
 

--- a/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
+++ b/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
@@ -38,8 +38,8 @@ public class CSharpPrinter extends CSVisitor {
 	public CSharpPrinter() {
 	}
 	
-	public void setWriter(Writer writer, String indentString) {
-		_writer = new IndentedWriter(writer);
+	public void setWriter(Writer writer, String indentString, int maxColumns) {
+		_writer = new IndentedWriter(writer, maxColumns);
 		if (indentString != null) {
 			_writer.setIndentString(indentString);
 		}

--- a/sharpen.core/src/sharpen/core/io/IndentedWriter.java
+++ b/sharpen.core/src/sharpen/core/io/IndentedWriter.java
@@ -28,7 +28,7 @@ import java.io.Writer;
 
 public class IndentedWriter {
 
-	private static final int MAX_COLUMNS = 80;
+	private final int _maxColumns;
 
 	String _lineSeparator = System.getProperty("line.separator");
 
@@ -42,8 +42,9 @@ public class IndentedWriter {
 
 	private String _prefix;
 
-	public IndentedWriter(Writer writer) {
+	public IndentedWriter(Writer writer, int maxColumns) {
 		_delegate = writer;
+		_maxColumns = maxColumns;
 	}
 
 	public String getIndentString() {
@@ -74,7 +75,7 @@ public class IndentedWriter {
 	}
 
 	public void write(String s) {
-		if (_column > MAX_COLUMNS) {
+		if (_column > _maxColumns) {
 			writeLine();
 			writeIndented(_indentString);
 		}


### PR DESCRIPTION
The default wrapping width is 80 columns, but this can now be changed by specifying `-maxColumns` on the command line. For example, `-maxColumns 1000` will set the wrapping width to 1000.
