### PR TITLE
Add new option -separateInterfaceConstants, which places interface const...

### DIFF
--- a/sharpen.core/src/sharpen/core/Configuration.java
+++ b/sharpen.core/src/sharpen/core/Configuration.java
@@ -88,6 +88,8 @@ public abstract class Configuration {
 
 	private boolean _nativeInterfaces;
 	
+	private boolean _separateInterfaceConstants;
+
 	private boolean _organizeUsings;
 	
 	private boolean _paramCountFileNames;
@@ -395,6 +397,14 @@ public abstract class Configuration {
 		_nativeInterfaces = true;
 	}
 	
+	public boolean separateInterfaceConstants() {
+		return _separateInterfaceConstants;
+	}
+
+	public void enableSeparateInterfaceConstants() {
+		_separateInterfaceConstants = true;
+	}
+
 	public void enableOrganizeUsings() {
 		_organizeUsings = true;
 	}

--- a/sharpen.core/src/sharpen/core/SharpenApplication.java
+++ b/sharpen.core/src/sharpen/core/SharpenApplication.java
@@ -123,6 +123,10 @@ public class SharpenApplication implements IApplication {
 			ods("Native interfaces mode on.");
 			configuration.enableNativeInterfaces();
 		}
+		if (_args.separateInterfaceConstants) {
+			ods("Separating interface constants to their own classes.");
+			configuration.enableSeparateInterfaceConstants();
+		}
 		if (_args.organizeUsings) {
 			ods("Organize usings mode on.");
 			configuration.enableOrganizeUsings();

--- a/sharpen.core/src/sharpen/core/SharpenCommandLine.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLine.java
@@ -73,6 +73,7 @@ public class SharpenCommandLine {
 	final public List<Configuration.NameMapping> typeMappings = new ArrayList<Configuration.NameMapping>();
 	final public Map<String, Configuration.MemberMapping> memberMappings = new HashMap<String, Configuration.MemberMapping>();
 	public boolean nativeInterfaces;
+	public boolean separateInterfaceConstants;
 	public boolean organizeUsings;
 	public boolean paramCountFileNames;
 	final public List<String> fullyQualifiedTypes = new ArrayList<String>();

--- a/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
@@ -91,6 +91,8 @@ class SharpenCommandLineParser extends CommandLineParser {
 			_cmdLine.indentSize = Integer.parseInt(consumeNext());
 		} else if (areEqual(arg, "-nativeInterfaces")) {
 			_cmdLine.nativeInterfaces = true;
+		} else if (areEqual(arg, "-separateInterfaceConstants")) {
+			_cmdLine.separateInterfaceConstants = true;
 		} else if (areEqual(arg, "-organizeUsings")) {
 			_cmdLine.organizeUsings = true;
 		} else if (areEqual(arg, "-continueOnError")) {

--- a/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
+++ b/sharpen.core/src/sharpen/core/csharp/CSharpPrinter.java
@@ -1005,6 +1005,7 @@ public class CSharpPrinter extends CSVisitor {
 		switch (modifier) {
 		case Abstract: return "abstract ";
 		case Sealed: return "sealed ";
+		case Static: return "static ";
 		}
 		return "";
 	}

--- a/sharpen.core/src/sharpen/core/csharp/ast/CSClassModifier.java
+++ b/sharpen.core/src/sharpen/core/csharp/ast/CSClassModifier.java
@@ -28,5 +28,6 @@ package sharpen.core.csharp.ast;
 public enum CSClassModifier {
 	Abstract,
 	Sealed,
+	Static,
 	None
 }


### PR DESCRIPTION
This option places interface constants into their own class, removing the requirement that such an interface be translated to an `abstract class`. For example, the following interface:

``` java
public interface Foo {
    const int MyConstant = 3;
    void foo();
}
```

Would now get translated to this:

``` csharp
public interface IFoo {
    void Foo();
}

public static class FooConstants {
    public const int MyConstant = 3;
}
```
