### PR TITLE
Add the -sharpenNamespace command line argument

### DIFF
--- a/sharpen.core/src/sharpen/core/CSharpBuilder.java
+++ b/sharpen.core/src/sharpen/core/CSharpBuilder.java
@@ -109,7 +109,7 @@ public class CSharpBuilder extends ASTVisitor {
 		_ast = my(CompilationUnit.class);
 		_resolver = my(ASTResolver.class);
 		_compilationUnit = my(CSCompilationUnit.class);
-		_compilationUnit.addUsing(new CSUsing ("Sharpen"));
+		_compilationUnit.addUsing(new CSUsing (_configuration.sharpenNamespace()));
 	}
 
 	protected CSharpBuilder(CSharpBuilder other) {

--- a/sharpen.core/src/sharpen/core/Configuration.java
+++ b/sharpen.core/src/sharpen/core/Configuration.java
@@ -98,6 +98,8 @@ public abstract class Configuration {
 
 	private boolean _junitConvert;
 	
+	private String _sharpenNamespace = "Sharpen";
+
 	private List<String> _fullyQualifiedTypes = new ArrayList<String>();
 	
 	private boolean _createProblemMarkers = false;
@@ -437,6 +439,15 @@ public abstract class Configuration {
 	
 	public boolean junitConversion () {
 		return _junitConvert;
+	}
+
+	public void setSharpenNamespace(String sharpenNamespace) {
+		if (null == sharpenNamespace) throw new IllegalArgumentException("sharpenNamespace");
+		_sharpenNamespace = sharpenNamespace;
+	}
+
+	public String sharpenNamespace() {
+		return _sharpenNamespace;
 	}
 	
 	public void addFullyQualifiedTypeName(String name) {

--- a/sharpen.core/src/sharpen/core/SharpenApplication.java
+++ b/sharpen.core/src/sharpen/core/SharpenApplication.java
@@ -142,6 +142,10 @@ public class SharpenApplication implements IApplication {
 			ods("JUnit conversion mode on.");
 			configuration.enableJUnitConversion();
 		}
+		if (_args.sharpenNamespace != null) {
+			ods("Sharpen namespace: " + _args.sharpenNamespace);
+			configuration.setSharpenNamespace(_args.sharpenNamespace);
+		}
 		if (_args.headerFile != null) {
 			ods("Header file: " + _args.headerFile);
 			configuration.setHeader(IO.readFile(new File(_args.headerFile)));

--- a/sharpen.core/src/sharpen/core/SharpenCommandLine.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLine.java
@@ -86,4 +86,5 @@ public class SharpenCommandLine {
 	public final Map<String, String> conditionalCompilation = new HashMap<String, String>();
 	public String configurationClass;
 	public boolean junitConversion;
+	public String sharpenNamespace;
 }

--- a/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
+++ b/sharpen.core/src/sharpen/core/SharpenCommandLineParser.java
@@ -138,6 +138,8 @@ class SharpenCommandLineParser extends CommandLineParser {
 			_cmdLine.configurationClass = consumeNext();		
 		} else if (areEqual(arg, "-junitConversion")) {
 			_cmdLine.junitConversion = true;		
+		} else if (areEqual(arg, "-sharpenNamespace")) {
+			_cmdLine.sharpenNamespace = consumeNext();		
 		} else {
 			illegalArgument(arg);
 		}


### PR DESCRIPTION
Add `-sharpenNamespace Custom.Sharpen` to the command line and you'll get `using Custom.Sharpen;` instead of `using Sharpen;` in the output. :smile: 
